### PR TITLE
Solution to issue #273

### DIFF
--- a/gs_quant/entities/entity.py
+++ b/gs_quant/entities/entity.py
@@ -111,6 +111,7 @@ class Entity(metaclass=ABCMeta):
             id_type: Union[EntityIdentifier, str],
             entity_type: Optional[Union[EntityType, str]] = None):
         id_type = id_type.value if isinstance(id_type, Enum) else id_type
+        id_value = id_value.lower()  # Convert to lowercase
 
         if entity_type is None:
             entity_type = cls.entity_type()


### PR DESCRIPTION
The issue is that some functionalities of the Country class expect the input for id to be in lower case, otherwise the 'get' function, for example, returns nothing. The issue is highlighted in #273.