### PR TITLE
FIX: add the missing import for logging

### DIFF
--- a/gs_quant/timeseries/backtesting.py
+++ b/gs_quant/timeseries/backtesting.py
@@ -22,6 +22,7 @@ from pydash import chunk
 from gs_quant.timeseries.econometrics import volatility, correlation
 from gs_quant.timeseries.helper import _create_enum, _tenor_to_month, _month_to_tenor
 from gs_quant.timeseries.measures_helper import VolReference, preprocess_implied_vol_strikes_eq
+import logging
 from gs_quant import timeseries as ts
 from .statistics import *
 from ..api.gs.assets import GsAssetApi


### PR DESCRIPTION
Without importing the logging module, _logger = logging.getLogger() would raise a NameError at runtime. Importing logging at the top of the file ensures the logger is defined properly, preventing the runtime error. 
FIX: [https://github.com/goldmansachs/gs-quant/issues/315](https://github.com/goldmansachs/gs-quant/issues/315)