### PR TITLE
FIX: Enable hostname and cert verification

### DIFF
--- a/gs_quant/session.py
+++ b/gs_quant/session.py
@@ -69,8 +69,8 @@ class CustomHttpAdapter(requests.adapters.HTTPAdapter):
     def ssl_context(cls) -> ssl.SSLContext:
         if cls.__ssl_ctx is None:
             cls.__ssl_ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
-            cls.__ssl_ctx.check_hostname = False
-            cls.__ssl_ctx.verify_mode = 0
+            cls.__ssl_ctx.check_hostname = True                # enable hostname verification
+            cls.__ssl_ctx.verify_mode = ssl.CERT_REQUIRED       # require valid certificates
             cls.__ssl_ctx.options |= 0x4  # OP_LEGACY_SERVER_CONNECT
             cls.__ssl_ctx.load_default_certs()
             cls.__ssl_ctx.load_verify_locations(certifi.where())


### PR DESCRIPTION
In the original code, check_hostname=False and verify_mode=0 effectively turn off SSL certificate validation and that could raise concern regarding  security. The updated code enforces ssl.CERT_REQUIRED and keep hostname checking on, ensuring SSL certificates is properly validated results in  hardens the connection security by preventing unauthorized or unverified certificates from being accepted. 
FIX: [https://github.com/goldmansachs/gs-quant/issues/319](https://github.com/goldmansachs/gs-quant/issues/319)