### PR TITLE
Fixing grammatical error in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ pip install gs-quant
 
 ## Examples
 
-You can find examples, guides and tutorials in the respective folders as well as on [Goldman Sachs Developer](https://developer.gs.com/docs/gsquant/).
+You can find examples, guides and tutorials in the respective folders on [Goldman Sachs Developer](https://developer.gs.com/docs/gsquant/).
 
 ## Contributions
 


### PR DESCRIPTION
fixed grammatical error in the examples section.  Removed "as well as" to make the sentence complete.

before fix:
You can find examples, guides and tutorials in the respective folders **as well as** on [Goldman Sachs Developer]

after fix:
You can find examples, guides and tutorials in the respective folders on [Goldman Sachs Developer](https://developer.gs.com/docs/gsquant/).