### PR TITLE
Fix Dataset.get_data to only return requested fields (Issue #280)

### DIFF
--- a/dco/Jakiur Rahman.dco
+++ b/dco/Jakiur Rahman.dco
@@ -1,0 +1,9 @@
+1) I, Jakiur Rahman, certify that all work committed with the commit message
+"covered by: <YOUR NAME>.dco" is my original work and I own the copyright
+to this work. I agree to contribute this code under the Apache 2.0 license.
+
+2) I understand and agree all contribution including all personal
+information I submit with it is maintained indefinitely and may be
+redistributed consistent with the open source license(s) involved.
+
+This certification is effective for all code contributed from 2025-10-02 to 9999-01-01.


### PR DESCRIPTION
Fixes Issue #280: Dataset.get_data(fields=[...]) returned all dataset columns with non-selected ones filled with NaN.

Changes:
- Add Dataset._filter_df_by_fields that sanitizes requested field names (function-style + camelCase -> snake_case)
  and filters the DataFrame returned by the provider to only the requested columns that exist.
- Apply the filter in the dataframe construction paths so that when `fields` is provided users get only
  the selected columns (no NaN columns).
- Add unit test (gs_quant/test/data/test_dataset.py::test_get_data_filters_to_requested_fields) that uses a
  DummyProvider to validate the behavior without network calls.

Notes & rationale:
- If none of the requested fields match provider columns, the original DataFrame is preserved to avoid
  unexpectedly dropping all data (non-breaking default). Maintainers may request a stricter behavior; happy to adjust.
- The code uses `inflection.underscore` when available; a small fallback is provided if not present.

covered by: Jakiur Rahman.dco
