### PR TITLE
Fix pandas 2.x compat: replace DataFrame.append with pd.concat

### DIFF
--- a/gs_quant/analytics/processors/utility_processors.py
+++ b/gs_quant/analytics/processors/utility_processors.py
@@ -169,7 +169,7 @@ class AppendProcessor(BaseProcessor):
         b_data = self.children_data.get('b')
         if isinstance(a_data, ProcessorResult) and isinstance(b_data, ProcessorResult):
             if a_data.success and b_data.success:
-                result = a_data.data.append(b_data.data)
+                result = pd.concat([a_data.data, b_data.data])
                 self.value = ProcessorResult(True, result)
             else:
                 self.value = ProcessorResult(False, "Processor does not have A and B data yet")

--- a/gs_quant/entities/tree_entity.py
+++ b/gs_quant/entities/tree_entity.py
@@ -110,10 +110,10 @@ class AssetTreeNode:
 
             for key, value in node.data.items():
                 data[key] = value
-            constituents_df = constituents_df.append(pd.DataFrame(data, index=[0]))
+            constituents_df = pd.concat([constituents_df, pd.DataFrame(data, index=[0])], ignore_index=True)
             d = node.__build_constituents_df(pd.DataFrame())
             if len(d) > 0:
-                constituents_df = constituents_df.append(d)
+                constituents_df = pd.concat([constituents_df, d], ignore_index=True)
         return constituents_df
 
 

--- a/gs_quant/markets/hedge.py
+++ b/gs_quant/markets/hedge.py
@@ -947,7 +947,7 @@ class Hedge:
         prices_df = pd.DataFrame()
         for date in backtest_dates:
             data = thomson_reuters_eod_data.get_data(date, date, assetId=portfolio_asset_ids)
-            prices_df = prices_df.append(data)
+            prices_df = pd.concat([prices_df, data], ignore_index=True)
         for asset_id in portfolio_asset_ids:
             id_prices_map[asset_id] = list(prices_df.loc[prices_df['assetId'] == asset_id]['closePrice'])
 

--- a/gs_quant/risk/results.py
+++ b/gs_quant/risk/results.py
@@ -126,7 +126,7 @@ def _compose(lhs: ResultInfo, rhs: ResultInfo) -> ResultInfo:
             if rhs.index.name != 'date':
                 rhs = rhs.assign(date=rhs.risk_key.date).set_index('date')
 
-            return lhs.loc[set(lhs.index) - set(rhs.index)].append(rhs).sort_index()
+            return pd.concat([lhs.loc[set(lhs.index) - set(rhs.index)], rhs]).sort_index()
     elif isinstance(lhs, MultipleRiskMeasureResult):
         if isinstance(rhs, MultipleRiskMeasureResult):
             return lhs + rhs


### PR DESCRIPTION
## Summary

Fixes #337. `DataFrame.append` and `Series.append` were removed in pandas 2.0, causing `AttributeError` for users on pandas >= 2.

Replaced all 5 occurrences across 4 files with `pd.concat`:

- `gs_quant/analytics/processors/utility_processors.py` (line 172)
- `gs_quant/entities/tree_entity.py` (lines 113, 116)
- `gs_quant/markets/hedge.py` (line 950)
- `gs_quant/risk/results.py` (line 129)

List `.append()` calls (which are valid) were left unchanged.

## Test plan
- Verified no remaining `DataFrame.append` / `Series.append` in affected files
- `pd.concat` is a drop-in replacement with identical behavior for these use cases