### PR TITLE
Add Stochastic Oscillator and Average True Range to technicals module

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,3 +1,4 @@
 gs-quant
 Copyright 2018-2019 Goldman Sachs
 This product contains code copyright Scott Weinstein, licensed under Apache 2.0 license
+This product contains code copyright Vedant Agarwal, licensed under Apache 2.0 license

--- a/dco/Vedant Agarwal.dco
+++ b/dco/Vedant Agarwal.dco
@@ -1,0 +1,9 @@
+1) I, Vedant Agarwal, certify that all work committed with the commit message
+"covered by: Vedant Agarwal.dco" is my original work and I own the copyright
+to this work. I agree to contribute this code under the Apache 2.0 license.
+
+2) I understand and agree all contribution including all personal
+information I submit with it is maintained indefinitely and may be
+redistributed consistent with the open source license(s) involved.
+
+This certification is effective for all code contributed from 2026-06-08 to 9999-01-01.

--- a/dco/Vedant Agarwal.dco
+++ b/dco/Vedant Agarwal.dco
@@ -2,7 +2,7 @@
 "covered by: Vedant Agarwal.dco" is my original work and I own the copyright
 to this work. I agree to contribute this code under the Apache 2.0 license.
 
-2) I understand and agree all contribution including all personal
+2) I understand and agree all contributions including all personal
 information I submit with it is maintained indefinitely and may be
 redistributed consistent with the open source license(s) involved.
 

--- a/gs_quant/test/timeseries/test_technicals.py
+++ b/gs_quant/test/timeseries/test_technicals.py
@@ -36,6 +36,7 @@ from gs_quant.timeseries import (
     Frequency,
     seasonally_adjusted,
 )
+from gs_quant.timeseries.technicals import stochastic_oscillator, average_true_range
 
 
 def test_moving_average():
@@ -301,6 +302,100 @@ def test_seasonality_adjusted():
     with pytest.raises(MqValueError):
         x = pd.Series(range(10))
         seasonally_adjusted(x)
+
+
+def test_stochastic_oscillator():
+    dates = [
+        dt.date(2019, 1, 1),
+        dt.date(2019, 1, 2),
+        dt.date(2019, 1, 3),
+        dt.date(2019, 1, 4),
+        dt.date(2019, 1, 5),
+        dt.date(2019, 1, 6),
+    ]
+
+    x = pd.Series([3.0, 2.0, 3.0, 1.0, 3.0, 6.0], index=dates)
+
+    result = stochastic_oscillator(x, 3, 3)
+    assert isinstance(result, pd.DataFrame)
+    assert list(result.columns) == ['pctK', 'pctD']
+    assert len(result) == len(x)
+
+    # %K should be between 0 and 100 (NaN allowed for initial ramp)
+    pct_k = result['pctK'].dropna()
+    assert (pct_k >= 0).all() and (pct_k <= 100).all()
+
+    # When the price is at the high of the window, %K should be 100
+    # At index 5 (value 6.0), over window 3 the values are [1.0, 3.0, 6.0]
+    # %K = (6 - 1) / (6 - 1) * 100 = 100
+    assert result['pctK'].iloc[5] == 100.0
+
+    # When the price is at the low of the window, %K should be 0
+    # At index 3 (value 1.0), over window 3 the values are [2.0, 3.0, 1.0]
+    # %K = (1 - 1) / (3 - 1) * 100 = 0
+    assert result['pctK'].iloc[3] == 0.0
+
+    # Test with empty series
+    result = stochastic_oscillator(pd.Series(dtype=float), 14, 3)
+    assert isinstance(result, pd.DataFrame)
+    assert result.empty
+
+    # Test with flat prices (all same value) - should produce NaN since range is 0
+    flat = pd.Series([5.0, 5.0, 5.0, 5.0], index=dates[:4])
+    result = stochastic_oscillator(flat, 3, 3)
+    assert result['pctK'].iloc[-1] != result['pctK'].iloc[-1]  # NaN check
+
+    # Test with string window
+    dates_dt = pd.date_range('2019-01-01', periods=6, freq='D')
+    x_dt = pd.Series([3.0, 2.0, 3.0, 1.0, 3.0, 6.0], index=dates_dt)
+    result = stochastic_oscillator(x_dt, "3d", 3)
+    assert isinstance(result, pd.DataFrame)
+
+
+def test_average_true_range():
+    dates = [
+        dt.date(2019, 1, 1),
+        dt.date(2019, 1, 2),
+        dt.date(2019, 1, 3),
+        dt.date(2019, 1, 4),
+        dt.date(2019, 1, 5),
+        dt.date(2019, 1, 6),
+    ]
+
+    x = pd.Series([3.0, 2.0, 3.0, 1.0, 3.0, 6.0], index=dates)
+
+    result = average_true_range(x, 3)
+    assert isinstance(result, pd.Series)
+    assert len(result) == len(x)
+
+    # ATR should be non-negative (except for NaN at the start from diff)
+    assert (result.dropna() >= 0).all()
+
+    # The true ranges are: NaN, |2-3|=1, |3-2|=1, |1-3|=2, |3-1|=2, |6-3|=3
+    # ATR(3) at index 5: mean of [2, 2, 3] = 7/3 = 2.333...
+    assert np.isclose(result.iloc[5], 7 / 3, atol=1e-4)
+
+    # ATR(3) at index 4: mean of [1, 2, 2] = 5/3 = 1.666...
+    assert np.isclose(result.iloc[4], 5 / 3, atol=1e-4)
+
+    # Test with empty series
+    result = average_true_range(pd.Series(dtype=float), 14)
+    assert result.empty
+
+    # Test with constant series (no price movement -> ATR should be 0)
+    flat = pd.Series([5.0, 5.0, 5.0, 5.0], index=dates[:4])
+    result = average_true_range(flat, 3)
+    assert result.iloc[-1] == 0.0
+
+    # Test with string window
+    dates_dt = pd.date_range('2019-01-01', periods=6, freq='D')
+    x_dt = pd.Series([3.0, 2.0, 3.0, 1.0, 3.0, 6.0], index=dates_dt)
+    result = average_true_range(x_dt, "3d")
+    assert isinstance(result, pd.Series)
+
+    # Test Window object with ramp
+    result = average_true_range(x, Window(3, 2))
+    assert isinstance(result, pd.Series)
 
 
 if __name__ == "__main__":

--- a/gs_quant/test/timeseries/test_technicals.py
+++ b/gs_quant/test/timeseries/test_technicals.py
@@ -343,7 +343,7 @@ def test_stochastic_oscillator():
     # Test with flat prices (all same value) - should produce NaN since range is 0
     flat = pd.Series([5.0, 5.0, 5.0, 5.0], index=dates[:4])
     result = stochastic_oscillator(flat, 3, 3)
-    assert result['pctK'].iloc[-1] != result['pctK'].iloc[-1]  # NaN check
+    assert pd.isna(result['pctK'].iloc[-1])  # NaN for flat price (zero range)
 
     # Test with string window
     dates_dt = pd.date_range('2019-01-01', periods=6, freq='D')

--- a/gs_quant/timeseries/technicals.py
+++ b/gs_quant/timeseries/technicals.py
@@ -408,6 +408,124 @@ def exponential_spread_volatility(x: pd.Series, beta: float = 0.75) -> pd.Series
     return annualize(exponential_std(diff(x, 1), beta))
 
 
+@plot_function
+def stochastic_oscillator(x: pd.Series, w: Union[Window, int, str] = 14, s: int = 3) -> pd.DataFrame:
+    """
+    Stochastic Oscillator (%K and %D)
+
+    :param x: time series of prices
+    :param w: Window or int: lookback period for %K calculation. e.g. Window(14, 10) where 14 is the window size
+              and 10 the ramp up value.  If w is a string, it should be a relative date like '1m', '1d', etc.
+              Defaults to 14 observations.
+    :param s: smoothing period for %D (simple moving average of %K). Defaults to 3.
+    :return: DataFrame with two columns: 'pctK' and 'pctD'
+
+    **Usage**
+
+    The `Stochastic Oscillator <https://en.wikipedia.org/wiki/Stochastic_oscillator>`_ is a momentum indicator that
+    compares a security's closing price to its price range over a given lookback period. It generates values between
+    0 and 100.
+
+    %K (fast stochastic) is calculated as:
+
+    :math:`\\%K_t = \\frac{X_t - L_w}{H_w - L_w} \\times 100`
+
+    where :math:`X_t` is the current price, :math:`L_w` is the lowest price over window :math:`w`, and :math:`H_w`
+    is the highest price over window :math:`w`.
+
+    %D (slow stochastic) is the simple moving average of %K over :math:`s` periods:
+
+    :math:`\\%D_t = \\frac{1}{s} \\sum_{i=0}^{s-1} \\%K_{t-i}`
+
+    Readings above 80 are generally considered overbought, while readings below 20 are considered oversold.
+    A common trading signal is when %K crosses above or below %D.
+
+    **Examples**
+
+    Generate price series and compute stochastic oscillator with default 14-day lookback:
+
+    >>> prices = generate_series(100)
+    >>> stochastic_oscillator(prices, 14, 3)
+
+    **See also**
+
+    :func:`relative_strength_index` :func:`moving_average`
+
+    """
+    w = normalize_window(x, w)
+    if x.empty:
+        return pd.DataFrame(columns=['pctK', 'pctD'], dtype=float)
+
+    if isinstance(w.w, pd.DateOffset):
+        rolling_low = x.rolling(w.w).min()
+        rolling_high = x.rolling(w.w).max()
+    else:
+        rolling_low = x.rolling(w.w, min_periods=1).min()
+        rolling_high = x.rolling(w.w, min_periods=1).max()
+
+    high_low_range = rolling_high - rolling_low
+    # Avoid division by zero when high == low (flat price)
+    high_low_range = high_low_range.replace(0, float('nan'))
+
+    pct_k = ((x - rolling_low) / high_low_range) * 100
+    pct_d = pct_k.rolling(s, min_periods=1).mean()
+
+    pct_k = apply_ramp(pct_k, w)
+    pct_d = apply_ramp(pct_d, w)
+
+    result = pd.concat([pct_k, pct_d], axis=1)
+    result.columns = ['pctK', 'pctD']
+    return result
+
+
+@plot_function
+def average_true_range(x: pd.Series, w: Union[Window, int, str] = 14) -> pd.Series:
+    """
+    Average True Range (ATR)
+
+    :param x: time series of prices
+    :param w: Window or int: size of window and ramp up to use. e.g. Window(14, 10) where 14 is the window size
+              and 10 the ramp up value.  If w is a string, it should be a relative date like '1m', '1d', etc.
+              Defaults to 14 observations.
+    :return: date-based time series of ATR
+
+    **Usage**
+
+    The `Average True Range <https://en.wikipedia.org/wiki/Average_true_range>`_ is a volatility indicator that
+    measures the degree of price movement for a given period. When only closing prices are available (as opposed
+    to OHLC data), the True Range simplifies to the absolute change between consecutive prices:
+
+    :math:`TR_t = |X_t - X_{t-1}|`
+
+    The ATR is then the moving average of the True Range over the specified window:
+
+    :math:`ATR_t = \\frac{1}{w} \\sum_{i=t-w+1}^{t} TR_i`
+
+    Higher ATR values indicate higher volatility. Unlike percentage-based volatility measures, ATR is expressed
+    in the same units as the price series, making it useful for setting stop-loss levels or position sizing.
+
+    **Examples**
+
+    Generate price series and compute ATR over a 14-day window:
+
+    >>> prices = generate_series(100)
+    >>> average_true_range(prices, 14)
+
+    **See also**
+
+    :func:`bollinger_bands` :func:`exponential_volatility` :func:`moving_average`
+
+    """
+    w = normalize_window(x, w)
+    if x.empty:
+        return pd.Series(dtype=float)
+
+    # True Range: when only close prices are available, TR = |close_t - close_{t-1}|
+    true_range = x.diff().abs()
+
+    return apply_ramp(mean(true_range, Window(w.w, 0)), w)
+
+
 def _freq_to_period(x: pd.Series, freq: Frequency = Frequency.YEAR):
     """
     Given input series x with a DateTimeIndex and a desired temporal frequency (period), returns x with all NaNs

--- a/gs_quant/timeseries/technicals.py
+++ b/gs_quant/timeseries/technicals.py
@@ -452,6 +452,9 @@ def stochastic_oscillator(x: pd.Series, w: Union[Window, int, str] = 14, s: int 
     :func:`relative_strength_index` :func:`moving_average`
 
     """
+    if not isinstance(s, int) or s <= 0:
+        raise MqValueError('s must be a positive integer.')
+
     w = normalize_window(x, w)
     if x.empty:
         return pd.DataFrame(columns=['pctK', 'pctD'], dtype=float)


### PR DESCRIPTION
Hey, I've been using gs-quant's technicals module and noticed that while it has a really solid foundation (moving averages, Bollinger Bands, RSI, MACD, EMA), it's missing a couple of indicators that are pretty standard in most trading toolkits. So I went ahead and added them.

## What's new

### Stochastic Oscillator
Returns a DataFrame with two columns:
- **%K** (fast line): measures where the current price sits relative to the rolling high-low range
- **%D** (slow line): simple moving average of %K for smoothing

This is one of the most widely used momentum indicators for identifying overbought/oversold conditions. Values above 80 suggest overbought, below 20 suggest oversold.

\\\python
prices = generate_series(100)
result = stochastic_oscillator(prices, 14, 3)  # 14-day lookback, 3-day smoothing
print(result[['pctK', 'pctD']])
\\\

### Average True Range (ATR)
Computes the rolling average of absolute price changes. Since gs-quant primarily works with closing prices (not OHLC data), the True Range simplifies to \|close_t - close_{t-1}|\. ATR is commonly used for:
- Setting stop-loss levels
- Position sizing
- Identifying volatility regime changes

\\\python
prices = generate_series(100)
atr = average_true_range(prices, 14)  # 14-day ATR
\\\

## Implementation details
Both functions follow the existing patterns in the module:
- Use the \@plot_function\ decorator (for Marquee Plot Service compatibility)
- Accept \Window\, \int\, or \str\ (e.g. '2w') for the window parameter
- Go through \
ormalize_window\ and \pply_ramp\ for consistent windowing/ramp behavior
- Handle edge cases: empty series, flat prices (division by zero), etc.
- Full docstrings with LaTeX math formulas and usage examples, matching the style of the rest of the module

## Testing
Added tests in \	est_technicals.py\ covering:
- Basic computation with known values
- Boundary conditions (%K = 100 at window high, %K = 0 at window low)
- Edge cases: empty series, flat prices, string date windows
- Window objects with ramp-up

## Files changed
| File | Change |
|------|--------|
| \gs_quant/timeseries/technicals.py\ | Added \stochastic_oscillator\ and \verage_true_range\ |
| \gs_quant/test/timeseries/test_technicals.py\ | Tests for both new functions |
| \NOTICE.txt\ | Contributor copyright |
| \dco/Vedant Agarwal.dco\ | DCO certification |

covered by: Vedant Agarwal.dco