### PR TITLE
fix: remove strptime calls on datetime.date objects in get_missing_dates and get_most_recent_date_from_calendar

### DIFF
--- a/gs_quant/models/risk_model.py
+++ b/gs_quant/models/risk_model.py
@@ -366,17 +366,14 @@ class MarqueeRiskModel(RiskModel):
             start_date = posted_dates[0]
         if not end_date:
             end_date = dt.date.today() - dt.timedelta(days=1)
-        calendar = [
-            dt.datetime.strptime(date, "%Y-%m-%d").date()
-            for date in self.get_calendar(start_date=start_date, end_date=end_date).business_dates
-        ]
+        calendar = list(self.get_calendar(start_date=start_date, end_date=end_date).business_dates)
         return [date for date in calendar if date not in posted_dates]
 
     def get_most_recent_date_from_calendar(self) -> dt.date:
         """Get T-1 date according to risk model calendar"""
         yesterday = dt.date.today() - dt.timedelta(1)
         calendar = self.get_calendar(end_date=yesterday).business_dates
-        return dt.datetime.strptime(calendar[len(calendar) - 1], '%Y-%m-%d').date()
+        return calendar[-1]
 
     def save(self):
         """Upload current Risk Model object to Marquee"""


### PR DESCRIPTION
## Fix 1 - `get_missing_dates`:
 
Chain is airtight:
 
- `RiskModelCalendar.business_dates: Tuple[datetime.date, ...]` declared in `target/risk_models.py:169`
- Old code called `strptime(date, "%Y-%m-%d")` on each element, raises `TypeError: strptime() argument 1 must be str, not datetime.date`. Provably broken.
- Fixed `list(...)` produces `List[datetime.date]`
- Downstream comparison `date not in posted_dates` where `posted_dates = self.get_dates()` returns `List[dt.date]` (line 288), types match
 
## Fix 2 - `get_most_recent_date_from_calendar`: 
 
- `calendar` is `self.get_calendar(...).business_dates`, a `Tuple[datetime.date]`
- Old code: `strptime(calendar[-1], '%Y-%m-%d').date()` raises same `TypeError`. Provably broken.
- Fixed: `calendar[-1]` is already `datetime.date`. Return type is `dt.date`. Done.
 