### PR TITLE
Handle date-based risk model calendars in MarqueeRiskModel helpers

### DIFF
--- a/gs_quant/models/risk_model.py
+++ b/gs_quant/models/risk_model.py
@@ -367,7 +367,7 @@ class MarqueeRiskModel(RiskModel):
         if not end_date:
             end_date = dt.date.today() - dt.timedelta(days=1)
         calendar = [
-            dt.datetime.strptime(date, "%Y-%m-%d").date()
+            dt.datetime.strptime(date, "%Y-%m-%d").date() if isinstance(date, str) else date
             for date in self.get_calendar(start_date=start_date, end_date=end_date).business_dates
         ]
         return [date for date in calendar if date not in posted_dates]
@@ -376,7 +376,8 @@ class MarqueeRiskModel(RiskModel):
         """Get T-1 date according to risk model calendar"""
         yesterday = dt.date.today() - dt.timedelta(1)
         calendar = self.get_calendar(end_date=yesterday).business_dates
-        return dt.datetime.strptime(calendar[len(calendar) - 1], '%Y-%m-%d').date()
+        most_recent = calendar[len(calendar) - 1]
+        return dt.datetime.strptime(most_recent, '%Y-%m-%d').date() if isinstance(most_recent, str) else most_recent
 
     def save(self):
         """Upload current Risk Model object to Marquee"""

--- a/gs_quant/test/models/test_risk_model.py
+++ b/gs_quant/test/models/test_risk_model.py
@@ -26,6 +26,7 @@ from gs_quant.models.risk_model_utils import get_optional_data_as_dataframe, _ma
 from gs_quant.session import GsSession, Environment
 from gs_quant.target.risk_models import (
     RiskModel as Risk_Model,
+    RiskModelCalendar,
     RiskModelCoverage,
     RiskModelTerm,
     RiskModelUniverseIdentifier,
@@ -1752,6 +1753,49 @@ def test_get_currency_exchange_rate(mocker):
     )
 
     assert_frame_equal(expected_data_frame, actual_data_frame, check_like=True)
+
+
+def test_get_missing_dates_accepts_date_objects(mocker):
+    model = FactorRiskModel(
+        'model_id',
+        'Fake Risk Model',
+        RiskModelCoverage.Country,
+        RiskModelTerm.Long,
+        RiskModelUniverseIdentifier.gsid,
+        'GS',
+        1.0,
+    )
+    mocker.patch.object(model, 'get_dates', return_value=[dt.date(2024, 1, 2)])
+    mocker.patch.object(
+        model,
+        'get_calendar',
+        return_value=RiskModelCalendar((dt.date(2024, 1, 1), dt.date(2024, 1, 2), dt.date(2024, 1, 3))),
+    )
+
+    missing = model.get_missing_dates(start_date=dt.date(2024, 1, 1), end_date=dt.date(2024, 1, 3))
+
+    assert missing == [dt.date(2024, 1, 1), dt.date(2024, 1, 3)]
+
+
+def test_get_most_recent_date_from_calendar_accepts_date_objects(mocker):
+    model = FactorRiskModel(
+        'model_id',
+        'Fake Risk Model',
+        RiskModelCoverage.Country,
+        RiskModelTerm.Long,
+        RiskModelUniverseIdentifier.gsid,
+        'GS',
+        1.0,
+    )
+    mocker.patch.object(
+        model,
+        'get_calendar',
+        return_value=RiskModelCalendar((dt.date(2024, 1, 2), dt.date(2024, 1, 3))),
+    )
+
+    most_recent = model.get_most_recent_date_from_calendar()
+
+    assert most_recent == dt.date(2024, 1, 3)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #344.

`RiskModelCalendar.business_dates` can now contain `datetime.date` objects, but `MarqueeRiskModel.get_missing_dates()` and `get_most_recent_date_from_calendar()` were still parsing every entry as a string. That left the calendar helpers inconsistent with `get_calendar()` and `risk_model_utils.get_closest_date_index()` once the calendar data switched types.

This keeps the existing string parsing path, but returns date entries directly when they are already `datetime.date` instances. I also added regression tests for both helpers using a `RiskModelCalendar` built from date objects.
