### PR TITLE
fix: handle datetime.date objects in get_missing_dates and get_most_recent_date_from_calendar

### DIFF
--- a/gs_quant/models/risk_model.py
+++ b/gs_quant/models/risk_model.py
@@ -367,7 +367,7 @@ class MarqueeRiskModel(RiskModel):
         if not end_date:
             end_date = dt.date.today() - dt.timedelta(days=1)
         calendar = [
-            dt.datetime.strptime(date, "%Y-%m-%d").date()
+            date if isinstance(date, dt.date) else dt.datetime.strptime(date, "%Y-%m-%d").date()
             for date in self.get_calendar(start_date=start_date, end_date=end_date).business_dates
         ]
         return [date for date in calendar if date not in posted_dates]
@@ -376,7 +376,8 @@ class MarqueeRiskModel(RiskModel):
         """Get T-1 date according to risk model calendar"""
         yesterday = dt.date.today() - dt.timedelta(1)
         calendar = self.get_calendar(end_date=yesterday).business_dates
-        return dt.datetime.strptime(calendar[len(calendar) - 1], '%Y-%m-%d').date()
+        last = calendar[len(calendar) - 1]
+        return last if isinstance(last, dt.date) else dt.datetime.strptime(last, '%Y-%m-%d').date()
 
     def save(self):
         """Upload current Risk Model object to Marquee"""

--- a/gs_quant/test/models/test_risk_model.py
+++ b/gs_quant/test/models/test_risk_model.py
@@ -1754,5 +1754,34 @@ def test_get_currency_exchange_rate(mocker):
     assert_frame_equal(expected_data_frame, actual_data_frame, check_like=True)
 
 
+def test_get_missing_dates_with_date_objects(mocker):
+    """get_missing_dates must not crash when business_dates contains datetime.date objects (regression for #344)."""
+    from gs_quant.api.gs.risk_models import GsRiskModelApi
+    from gs_quant.target.risk_models import RiskModelCalendar
+
+    model = mock_risk_model(mocker)
+
+    business_dates = (dt.date(2022, 1, 3), dt.date(2022, 1, 4), dt.date(2022, 1, 5))
+    mocker.patch.object(GsRiskModelApi, 'get_risk_model_calendar', return_value=RiskModelCalendar(business_dates))
+    mocker.patch.object(GsRiskModelApi, 'get_risk_model_dates', return_value=['2022-01-03', '2022-01-05'])
+
+    missing = model.get_missing_dates(start_date=dt.date(2022, 1, 3), end_date=dt.date(2022, 1, 5))
+    assert missing == [dt.date(2022, 1, 4)]
+
+
+def test_get_most_recent_date_from_calendar_with_date_objects(mocker):
+    """get_most_recent_date_from_calendar must not crash when business_dates contains datetime.date objects (#344)."""
+    from gs_quant.api.gs.risk_models import GsRiskModelApi
+    from gs_quant.target.risk_models import RiskModelCalendar
+
+    model = mock_risk_model(mocker)
+
+    business_dates = (dt.date(2022, 1, 3), dt.date(2022, 1, 4), dt.date(2022, 1, 5))
+    mocker.patch.object(GsRiskModelApi, 'get_risk_model_calendar', return_value=RiskModelCalendar(business_dates))
+
+    result = model.get_most_recent_date_from_calendar()
+    assert result == dt.date(2022, 1, 5)
+
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
Fixes #344.

## Problem

`RiskModelCalendar.business_dates` can now contain `datetime.date` objects, but `get_missing_dates()` and `get_most_recent_date_from_calendar()` were unconditionally calling `dt.datetime.strptime(date, ...)` on every entry. This raises a `TypeError` at runtime whenever the calendar uses date objects instead of strings.

## Fix

Added an `isinstance(date, dt.date)` guard in both helpers so that existing `datetime.date` entries are returned directly, while string entries continue to use the `strptime` path. The change is backward-compatible with no logic change for string-based calendars.

**`get_missing_dates`** (line ~370):
```python
# before
dt.datetime.strptime(date, "%Y-%m-%d").date()
# after
date if isinstance(date, dt.date) else dt.datetime.strptime(date, "%Y-%m-%d").date()
```

**`get_most_recent_date_from_calendar`** (line ~379):
```python
# before
return dt.datetime.strptime(calendar[-1], '%Y-%m-%d').date()
# after
last = calendar[-1]
return last if isinstance(last, dt.date) else dt.datetime.strptime(last, '%Y-%m-%d').date()
```

## Tests

Added two regression tests in `test_risk_model.py` that build a `RiskModelCalendar` from `datetime.date` objects and assert each helper returns the correct result without raising.