### PR TITLE
fix: serialize enum values in Portfolio.to_csv to enable CSV roundtrip

### DIFF
--- a/gs_quant/markets/portfolio.py
+++ b/gs_quant/markets/portfolio.py
@@ -25,6 +25,7 @@ from urllib.parse import quote
 import deprecation
 import numpy as np
 import pandas as pd
+from enum import Enum
 from more_itertools import unique_everseen
 
 from gs_quant.api.gs.assets import GsAssetApi
@@ -461,7 +462,7 @@ class Portfolio(PriceableImpl):
         port_df = self.to_frame(mappings or {})
         port_df = port_df[np.setdiff1d(port_df.columns, ignored_cols or [])]
         port_df = port_df.reset_index(drop=True)
-
+        port_df = port_df.apply(lambda col: col.map(lambda x: x.value if isinstance(x, Enum) else x))
         port_df.to_csv(csv_file)
 
     @property


### PR DESCRIPTION
Fixes #268.

## Problem

`Portfolio.to_csv()` writes enum fields (e.g. `AssetClass`, `Currency`, `PayReceive`) using their Python repr, which on some Python/enum versions produces class-qualified strings like `AssetClass.Rates` instead of the plain value `Rates`. `Portfolio.from_csv()` → `from_frame()` then calls `get_enum_value(AssetClass, 'AssetClass.Rates')` which fails to match any member, breaking the roundtrip entirely.

## Fix

One line added in `to_csv`: normalize all `Enum` cells to `.value` before writing.

```python
port_df = port_df.apply(lambda col: col.map(lambda x: x.value if isinstance(x, Enum) else x))
```

This is consistent with how `to_dict()` / JSON serialization already handles enums and matches what `from_frame()` expects when reading values back.

## Before / After

**Before:**
```
asset_class,notional_currency,pay_or_receive,type
AssetClass.Rates,Currency.EUR,PayReceive.Receive,AssetType.Swap
```

**After:**
```
asset_class,notional_currency,pay_or_receive,type
Rates,EUR,Receive,Swap
```