### PR TITLE
Handle date-based risk model calendars consistently

### DIFF
--- a/gs_quant/models/risk_model.py
+++ b/gs_quant/models/risk_model.py
@@ -367,7 +367,7 @@ class MarqueeRiskModel(RiskModel):
         if not end_date:
             end_date = dt.date.today() - dt.timedelta(days=1)
         calendar = [
-            dt.datetime.strptime(date, "%Y-%m-%d").date()
+            dt.datetime.strptime(date, "%Y-%m-%d").date() if isinstance(date, str) else date
             for date in self.get_calendar(start_date=start_date, end_date=end_date).business_dates
         ]
         return [date for date in calendar if date not in posted_dates]
@@ -376,7 +376,8 @@ class MarqueeRiskModel(RiskModel):
         """Get T-1 date according to risk model calendar"""
         yesterday = dt.date.today() - dt.timedelta(1)
         calendar = self.get_calendar(end_date=yesterday).business_dates
-        return dt.datetime.strptime(calendar[len(calendar) - 1], '%Y-%m-%d').date()
+        latest_date = calendar[len(calendar) - 1]
+        return dt.datetime.strptime(latest_date, '%Y-%m-%d').date() if isinstance(latest_date, str) else latest_date
 
     def save(self):
         """Upload current Risk Model object to Marquee"""

--- a/gs_quant/test/models/test_risk_model.py
+++ b/gs_quant/test/models/test_risk_model.py
@@ -26,6 +26,7 @@ from gs_quant.models.risk_model_utils import get_optional_data_as_dataframe, _ma
 from gs_quant.session import GsSession, Environment
 from gs_quant.target.risk_models import (
     RiskModel as Risk_Model,
+    RiskModelCalendar,
     RiskModelCoverage,
     RiskModelTerm,
     RiskModelUniverseIdentifier,
@@ -204,6 +205,44 @@ def test_update_risk_model(mocker):
     new_model.save()
     mocker.patch.object(GsSession.current.sync, 'get', return_value=new_model)
     assert new_model.type == RiskModelType.Thematic
+
+
+def test_get_missing_dates_handles_date_business_calendar(mocker):
+    model = mock_risk_model(mocker)
+    calendar_dates = (
+        dt.date(2026, 3, 31),
+        dt.date(2026, 4, 1),
+        dt.date(2026, 4, 2),
+    )
+
+    mocker.patch(
+        'gs_quant.api.gs.risk_models.GsRiskModelApi.get_risk_model_calendar',
+        return_value=RiskModelCalendar(calendar_dates),
+    )
+    mocker.patch.object(model, 'get_dates', return_value=[dt.date(2026, 3, 31), dt.date(2026, 4, 2)])
+
+    missing = model.get_missing_dates(start_date=dt.date(2026, 3, 31), end_date=dt.date(2026, 4, 2))
+
+    assert missing == [dt.date(2026, 4, 1)]
+
+
+def test_get_most_recent_date_from_calendar_returns_date_objects(mocker):
+    model = mock_risk_model(mocker)
+    yesterday = dt.date.today() - dt.timedelta(1)
+    calendar_dates = (
+        yesterday - dt.timedelta(days=2),
+        yesterday - dt.timedelta(days=1),
+        yesterday,
+    )
+
+    mocker.patch(
+        'gs_quant.api.gs.risk_models.GsRiskModelApi.get_risk_model_calendar',
+        return_value=RiskModelCalendar(calendar_dates),
+    )
+
+    most_recent = model.get_most_recent_date_from_calendar()
+
+    assert most_recent == yesterday
 
 
 def test_get_r_squared(mocker):


### PR DESCRIPTION
Fixes #344

## Summary
- keep `get_missing_dates()` working when risk model calendars already contain `datetime.date` objects
- keep `get_most_recent_date_from_calendar()` returning the latest date without forcing string parsing
- add regression tests for both methods using date-based calendars

## Testing
- python -m pytest -q gs_quant/test/models/test_risk_model.py -k "missing_dates_handles_date_business_calendar or most_recent_date_from_calendar_returns_date_objects"
- python -m pytest -q gs_quant/test/models/test_risk_model_utils.py -k "regression_date_objects_not_empty or regression_string_dates_still_work or regression_tuple_dates_work"