### PR TITLE
Relax pydash version constraint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "opentelemetry-api",
     "opentelemetry-sdk",
     "pandas>=1.4",
-    "pydash<7.0.0",
+    "pydash<8.0.0",
     "python-dateutil>=2.7.0",
     "requests",
     "httpx>=0.28.1",


### PR DESCRIPTION
## Summary
- relax the `pydash` dependency cap from `<7.0.0` to `<8.0.0`
- validate the current wrapper imports and targeted tests against `pydash 7.0.7`

## Testing
- `python -m pip install "pydash>=7,<8"`
- `python -m pytest -q gs_quant/test/test_base.py gs_quant/test/data/test_dataset.py gs_quant/test/data/test_dataset_tracing.py`
- import smoke test for modules using `get`, `has`, `set_`, `chunk`, `snake_case`, `camel_case`, and `decapitalize`

Closes #336