### PR TITLE
Fix look-ahead in backtest missing-data handling, broken MeanReversionTrigger, get_costs crash, and quant conventions

### DIFF
--- a/dco/Satish Rockzz.dco
+++ b/dco/Satish Rockzz.dco
@@ -1,0 +1,9 @@
+1) I, Satish Rockzz, certify that all work committed with the commit message
+"covered by: Satish Rockzz.dco" is my original work and I own the copyright
+to this work. I agree to contribute this code under the Apache 2.0 license.
+
+2) I understand and agree all contribution including all personal
+information I submit with it is maintained indefinitely and may be
+redistributed consistent with the open source license(s) involved.
+
+This certification is effective for all code contributed from 2026-07-17 to 9999-01-01.

--- a/gs_quant/api/gs/assets.py
+++ b/gs_quant/api/gs/assets.py
@@ -363,9 +363,11 @@ class GsAssetApi:
         identifier: [str],
         fields: IdList = [],
         limit: int = 100,
-        as_of: dt.datetime = dt.datetime.today(),
+        as_of: Optional[dt.datetime] = None,
         **kwargs,
     ) -> Tuple[dict, ...]:
+        if as_of is None:
+            as_of = dt.datetime.today()
         where = dict(identifier=identifier, **kwargs)
         query = dict(where=where, limit=limit, fields=fields, asOfTime=as_of.strftime("%Y-%m-%dT%H:%M:%SZ"))
         return GsSession.current.sync.post('/positions/resolver', payload=query)
@@ -376,9 +378,11 @@ class GsAssetApi:
         identifier: [str],
         fields: IdList = [],
         limit: int = 100,
-        as_of: dt.datetime = dt.datetime.today(),
+        as_of: Optional[dt.datetime] = None,
         **kwargs,
     ) -> Tuple[dict, ...]:
+        if as_of is None:
+            as_of = dt.datetime.today()
         where = dict(identifier=identifier, **kwargs)
         query = dict(where=where, limit=limit, fields=fields, asOfTime=as_of.strftime("%Y-%m-%dT%H:%M:%SZ"))
 

--- a/gs_quant/backtests/backtest_objects.py
+++ b/gs_quant/backtests/backtest_objects.py
@@ -14,6 +14,8 @@ specific language governing permissions and limitations
 under the License.
 """
 
+import logging
+
 from abc import ABC
 from collections import defaultdict
 from copy import deepcopy
@@ -51,6 +53,8 @@ from gs_quant.risk import (
 )
 from gs_quant.risk.transform import Transformer
 from gs_quant.risk.results import PricingFuture, PortfolioRiskResult
+
+logger = logging.getLogger(__name__)
 
 
 class BaseBacktest(ABC):
@@ -443,6 +447,7 @@ class BackTest(BaseBacktest):
             ledger = self.trade_ledger()
             num_trades = len(ledger)
         except Exception:
+            logger.warning('unable to compute trade ledger for summary stats; Total Trades set to NaN', exc_info=True)
             num_trades = np.nan
 
         # Annualised return and volatility
@@ -454,9 +459,8 @@ class BackTest(BaseBacktest):
         # Sharpe ratio (excess return over zero risk-free rate)
         sharpe = ann_return / ann_vol if ann_vol != 0 else np.nan
 
-        # Sortino ratio (downside deviation)
-        downside = daily_pnl[daily_pnl < 0]
-        downside_std = np.sqrt((downside**2).mean()) if len(downside) > 0 else 0.0
+        # Sortino ratio (downside deviation: squared below-zero deviations averaged over all periods)
+        downside_std = np.sqrt((np.minimum(daily_pnl, 0) ** 2).mean()) if num_periods > 0 else 0.0
         ann_downside = downside_std * np.sqrt(annualisation_factor)
         sortino = ann_return / ann_downside if ann_downside != 0 else np.nan
 
@@ -899,7 +903,7 @@ class PredefinedAssetBacktest(BaseBacktest):
         costs = defaultdict(float)
         for order in self.orders:
             if isinstance(order, OrderCost):
-                costs[order.execution_end_time().date()] += order.execution_quantity(self.data_handler)
+                costs[order.execution_end_time().date()] += order.execution_quantity()
 
         return pd.Series(costs)
 
@@ -965,7 +969,9 @@ class OisFixingCashAccrualModel(CashAccrualModel):
     class_type: str = static_field('ois_fixing_cash_accrual_model')
 
     def get_accrued_value(self, current_value, to_state) -> dict:
-        for currency in current_value[0].keys():
+        new_value = {}
+        from_state = current_value[1]
+        for currency, value in current_value[0].items():
             if currency not in ois_fixings:
                 start_date = (
                     self.start_date
@@ -990,7 +996,9 @@ class OisFixingCashAccrualModel(CashAccrualModel):
                     MissingDataStrategy.fill_forward,
                 )
             ds_accrual_model = DataCashAccrualModel(ois_fixings[currency], True)
-            return ds_accrual_model.get_accrued_value(current_value, to_state)
+            accrued = ds_accrual_model.get_accrued_value(({currency: value}, from_state), to_state)
+            new_value[currency] = accrued[currency]
+        return new_value
 
 
 def fx_pnl_definition() -> PnlDefinition:

--- a/gs_quant/backtests/data_sources.py
+++ b/gs_quant/backtests/data_sources.py
@@ -122,6 +122,11 @@ class GenericDataSource(DataSource):
     def get_data(self, state: Union[dt.date, dt.datetime, Iterable]):
         """
         Get the value of the dataset at a time or date.  If a list of dates or times is provided return list of values
+        If the requested date or time is missing from the dataset the missing_data_strategy determines the result:
+        MissingDataStrategy.fill_forward returns the last observation at or before the requested date (causal, no
+        future data is used).  MissingDataStrategy.interpolate linearly interpolates using the surrounding
+        observations, including subsequent (future) ones, and is therefore not suitable for causal backtesting;
+        prefer fill_forward for backtests.  The underlying dataset is never modified.
         :param state: a date, datetime or a list of dates or datetimes
         :return: float value
         """
@@ -139,23 +144,17 @@ class GenericDataSource(DataSource):
         elif state in self.data_set or self.missing_data_strategy == MissingDataStrategy.fail:
             return self.data_set[state]
         else:
-            if isinstance(self.data_set.index, pd.DatetimeIndex):
-                self.data_set.at[pd.to_datetime(state)] = np.nan
-                self.data_set = self.data_set.sort_index()
-            else:
-                self.data_set.at[state] = np.nan
-            self.data_set.sort_index()
+            lookup_key = pd.to_datetime(state) if isinstance(self.data_set.index, pd.DatetimeIndex) else state
+            sorted_data = self.data_set.sort_index()
             if self.missing_data_strategy == MissingDataStrategy.interpolate:
-                self.data_set = self.data_set.interpolate()
+                interpolated = sorted_data.copy()
+                interpolated.at[lookup_key] = np.nan
+                return interpolated.sort_index().interpolate()[lookup_key]
             elif self.missing_data_strategy == MissingDataStrategy.fill_forward:
-                self.data_set = self.data_set.ffill()
+                # last observation at or before the requested date; no look-ahead
+                return sorted_data.asof(lookup_key)
             else:
                 raise RuntimeError(f'unrecognised missing data strategy: {str(self.missing_data_strategy)}')
-            return (
-                self.data_set[pd.to_datetime(state)]
-                if isinstance(self.data_set.index, pd.DatetimeIndex)
-                else self.data_set[state]
-            )
 
     def get_data_range(self, start: Union[dt.date, dt.datetime], end: Union[dt.date, dt.datetime, int]):
         """

--- a/gs_quant/backtests/triggers.py
+++ b/gs_quant/backtests/triggers.py
@@ -359,18 +359,18 @@ class MeanReversionTriggerRequirements(TriggerRequirements):
             if abs((current_price - rolling_mean) / rolling_std) > self.z_score_bound:
                 if current_price > rolling_mean:
                     self.current_position = -1
-                    return TriggerInfo(True, {AddTradeAction: AddTradeActionInfo(scaling=-1)})
+                    return TriggerInfo(True, {AddTradeAction: AddTradeActionInfo(scaling=-1, next_schedule=None)})
                 else:
                     self.current_position = 1
-                    return TriggerInfo(True, {AddTradeAction: AddTradeActionInfo(scaling=1)})
+                    return TriggerInfo(True, {AddTradeAction: AddTradeActionInfo(scaling=1, next_schedule=None)})
         elif self.current_position == 1:
             if current_price > rolling_mean:
-                self._current_position = 0
-                return TriggerInfo(True, {AddTradeAction: AddTradeActionInfo(scaling=-1)})
-        elif self.current_position == -1:
-            if current_price > rolling_mean:
                 self.current_position = 0
-                return TriggerInfo(True, {AddTradeAction: AddTradeActionInfo(scaling=1)})
+                return TriggerInfo(True, {AddTradeAction: AddTradeActionInfo(scaling=-1, next_schedule=None)})
+        elif self.current_position == -1:
+            if current_price < rolling_mean:
+                self.current_position = 0
+                return TriggerInfo(True, {AddTradeAction: AddTradeActionInfo(scaling=1, next_schedule=None)})
         else:
             raise RuntimeWarning(f'unexpected current position: {self.current_position}')
         return TriggerInfo(False)

--- a/gs_quant/models/risk_model.py
+++ b/gs_quant/models/risk_model.py
@@ -17,7 +17,7 @@ under the License.
 import datetime as dt
 import math
 from enum import Enum, auto
-from typing import List, Dict, Tuple, Union
+from typing import List, Dict, Optional, Tuple, Union
 import pandas as pd
 import numpy as np
 import logging
@@ -595,8 +595,8 @@ class MarqueeRiskModel(RiskModel):
 
     def get_intraday_factor_data(
         self,
-        start_time: dt.datetime = dt.datetime.now() - dt.timedelta(hours=3),
-        end_time: dt.datetime = dt.datetime.now(),
+        start_time: Optional[dt.datetime] = None,
+        end_time: Optional[dt.datetime] = None,
         factors: List[str] = None,
         factor_ids: List[str] = None,
         data_source: Union[IntradayFactorDataSource, str] = None,
@@ -663,6 +663,10 @@ class MarqueeRiskModel(RiskModel):
 
         :func:`get_many_factors :func:`get_factor_returns_by_name`
         """
+        if start_time is None:
+            start_time = dt.datetime.now() - dt.timedelta(hours=3)
+        if end_time is None:
+            end_time = dt.datetime.now()
         factor_categories = category_filter if category_filter else []
         intraday_factor_data = GsFactorRiskModelApi.get_risk_model_factor_data_intraday(
             self.id,

--- a/gs_quant/test/backtest/test_audit_regressions.py
+++ b/gs_quant/test/backtest/test_audit_regressions.py
@@ -1,0 +1,156 @@
+"""
+Copyright 2019 Goldman Sachs.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+"""
+
+import datetime as dt
+
+import numpy as np
+import pandas as pd
+
+from gs_quant.backtests.actions import AddTradeAction, AddTradeActionInfo
+from gs_quant.backtests.backtest_objects import BackTest
+from gs_quant.backtests.data_sources import GenericDataSource, MissingDataStrategy
+from gs_quant.backtests.order import OrderCost
+from gs_quant.backtests.triggers import MeanReversionTrigger, MeanReversionTriggerRequirements
+from gs_quant.instrument import IRSwap
+
+
+def test_generic_data_source_no_lookahead():
+    # fill_forward must return the last PAST observation, not a future one, and must not mutate the dataset
+    series = pd.Series({dt.date(2021, 1, 1): 1.0, dt.date(2021, 1, 5): 3.0})
+    ds = GenericDataSource(series, MissingDataStrategy.fill_forward)
+
+    assert ds.get_data(dt.date(2021, 1, 3)) == 1.0
+
+    # underlying dataset unchanged (no NaN row appended, no ffill applied in place)
+    assert len(ds.data_set) == 2
+    assert ds.data_set[dt.date(2021, 1, 1)] == 1.0
+    assert ds.data_set[dt.date(2021, 1, 5)] == 3.0
+
+    # exact dates still resolve directly
+    assert ds.get_data(dt.date(2021, 1, 5)) == 3.0
+
+
+def test_generic_data_source_no_lookahead_datetime_index():
+    series = pd.Series(
+        [1.0, 3.0], index=pd.DatetimeIndex([dt.datetime(2021, 1, 1, 12), dt.datetime(2021, 1, 5, 12)])
+    )
+    ds = GenericDataSource(series, MissingDataStrategy.fill_forward)
+
+    assert ds.get_data(dt.datetime(2021, 1, 3, 12)) == 1.0
+    assert len(ds.data_set) == 2
+
+
+def test_generic_data_source_interpolate_does_not_mutate():
+    series = pd.Series({dt.date(2021, 1, 1): 1.0, dt.date(2021, 1, 5): 3.0})
+    ds = GenericDataSource(series, MissingDataStrategy.interpolate)
+
+    assert ds.get_data(dt.date(2021, 1, 3)) == 2.0
+    assert len(ds.data_set) == 2
+
+
+def test_mean_reversion_trigger():
+    # price series engineered to walk through long entry, long exit, short entry, short exit
+    prices = pd.Series(
+        {
+            dt.date(2021, 1, 4): 100.0,
+            dt.date(2021, 1, 5): 102.0,
+            dt.date(2021, 1, 6): 100.5,
+            dt.date(2021, 1, 7): 90.0,  # far below rolling mean -> long entry
+            dt.date(2021, 1, 8): 101.0,  # back above rolling mean -> long exit
+            dt.date(2021, 1, 9): 115.0,  # far above rolling mean -> short entry
+            dt.date(2021, 1, 10): 95.0,  # back below rolling mean -> short exit
+        }
+    )
+    requirements = MeanReversionTriggerRequirements(
+        data_source=GenericDataSource(prices, MissingDataStrategy.fail),
+        z_score_bound=2.0,
+        rolling_mean_window=3,
+        rolling_std_window=3,
+    )
+    trigger = MeanReversionTrigger(requirements, [AddTradeAction(IRSwap())])
+
+    # warm-up dates: no position, no trigger
+    assert not requirements.has_triggered(dt.date(2021, 1, 6))
+
+    # long entry: price well below rolling mean
+    info = requirements.has_triggered(dt.date(2021, 1, 7))
+    assert info.triggered
+    assert info.info_dict[AddTradeAction].scaling == 1
+    assert requirements.current_position == 1
+
+    # long exit: price crosses back above the rolling mean
+    info = requirements.has_triggered(dt.date(2021, 1, 8))
+    assert info.triggered
+    assert info.info_dict[AddTradeAction].scaling == -1
+    assert requirements.current_position == 0
+
+    # short entry: price well above rolling mean
+    info = requirements.has_triggered(dt.date(2021, 1, 9))
+    assert info.triggered
+    assert info.info_dict[AddTradeAction].scaling == -1
+    assert requirements.current_position == -1
+
+    # short exit: price reverts back DOWN below the rolling mean
+    info = requirements.has_triggered(dt.date(2021, 1, 10))
+    assert info.triggered
+    assert info.info_dict[AddTradeAction].scaling == 1
+    assert requirements.current_position == 0
+
+    assert trigger.trigger_requirements is requirements
+
+
+def test_add_trade_action_info_next_schedule():
+    info = AddTradeActionInfo(scaling=1, next_schedule=None)
+    assert info.scaling == 1
+    assert info.next_schedule is None
+
+
+def test_order_cost_execution_quantity():
+    order = OrderCost('USD', 100.0, 'test', dt.datetime(2021, 1, 4, 12))
+    # execution_quantity takes no arguments; get_costs accumulates it per execution date
+    assert order.execution_quantity() == 100.0
+    costs = {order.execution_end_time().date(): order.execution_quantity()}
+    assert costs[dt.date(2021, 1, 4)] == 100.0
+
+
+class _StubBackTest(BackTest):
+    def __init__(self, summary, ledger_rows=2):
+        self._summary = summary
+        self._ledger_rows = ledger_rows
+
+    @property
+    def result_summary(self):
+        return self._summary
+
+    def trade_ledger(self):
+        return pd.DataFrame({'Instrument': range(self._ledger_rows)})
+
+
+def test_sortino_downside_std():
+    dates = pd.date_range(dt.date(2021, 1, 4), periods=4)
+    total = pd.Series([0.0, 1.0, -1.0, 2.0], index=dates)
+    summary = pd.DataFrame({BackTest.TOTAL_COLUMN: total})
+
+    stats = _StubBackTest(summary).summary_stats(annualisation_factor=252)
+
+    daily_pnl = total.diff().dropna()  # [1, -2, 3]
+    ann_return = daily_pnl.mean() * 252
+    # downside deviation: squared below-zero deviations averaged over ALL periods, not just losing days
+    downside_std = np.sqrt((np.minimum(daily_pnl, 0) ** 2).mean())
+    expected_sortino = ann_return / (downside_std * np.sqrt(252))
+
+    assert stats['Sortino Ratio'] == expected_sortino
+    assert stats['Total Trades'] == 2

--- a/gs_quant/timeseries/econometrics.py
+++ b/gs_quant/timeseries/econometrics.py
@@ -520,13 +520,17 @@ def annualize(x: pd.Series) -> pd.Series:
     """
     Annualize series based on sample observation frequency
 
-    :param x: time series of prices
+    :param x: time series of volatility-dimension quantities (e.g. realized volatility or standard deviation of
+              returns)
     :return: date-based time series of annualized values
 
     **Usage**
 
-    Based on number of days between observations, will determine an annualization factor and then adjust values
-    accordingly. Useful for annualizing daily or monthly returns
+    Based on number of days between observations, will determine an annualization factor and then scale values by the
+    square root of that factor. This square-root scaling is appropriate for volatility-dimension quantities (e.g.
+    standard deviation of daily or monthly returns). Note: annualizing mean returns requires multiplying by the
+    factor itself (or geometric compounding), not by its square root, so this function is not suitable for that
+    purpose
 
     :math:`Y_t = X_t * \\sqrt{F}`
 
@@ -545,14 +549,14 @@ def annualize(x: pd.Series) -> pd.Series:
 
     **Examples**
 
-    Annualize daily returns series:
+    Annualize a rolling standard deviation of daily returns:
 
     >>> prices = generate_series(100)
-    >>> ann = annualize(returns(prices))
+    >>> ann_vol = annualize(std(returns(prices), 22))
 
     **See also**
 
-    :func:`returns`
+    :func:`returns` :func:`volatility`
     """
 
     factor: int = _get_annualization_factor(x)

--- a/gs_quant/timeseries/statistics.py
+++ b/gs_quant/timeseries/statistics.py
@@ -1536,9 +1536,9 @@ class SEIRModel(SIRModel):
         self.sigma_init = sigma
         self.fit = fit
         self.fit_period = fit_period
-        self.beta_fixed = not (self.fit or (self.beta is None))
-        self.gamma_fixed = not (self.fit or (self.gamma is None))
-        self.sigma_fixed = not (self.fit or (self.sigma is None))
+        self.beta_fixed = not (self.fit or (self.beta_init is None))
+        self.gamma_fixed = not (self.fit or (self.gamma_init is None))
+        self.sigma_fixed = not (self.fit or (self.sigma_init is None))
 
         lens = [len(x) for x in (self.s, self.e, self.i, self.r)]
         dtype = float if max(lens) == min(lens) else object


### PR DESCRIPTION
## Summary

This PR fixes bugs found during a systematic audit of the backtests and timeseries packages. The three HIGH-severity items were runtime-confirmed (reproduced by execution) before being fixed, and a new offline regression test module locks them all in. DCO included (`dco/Satish Rockzz.dco`); the commit carries the `covered by:` line per CONTRIBUTING.md.

### 1. Look-ahead bias in `GenericDataSource.get_data` (backtests/data_sources.py)

When a backtest queries a date absent from the series (any holiday/gap), the missing-data path appended NaN at the end of a `dt.date`-indexed series — the subsequent `sort_index()`'s return value was discarded, making it a no-op — so `fillna(method="ffill")` filled the gap with the **last (future) value**. Repro: series `{1/1: 1.0, 1/5: 3.0}`, query `1/3` with `fill_forward` → returned **3.0** (the future price). The lookup also mutated the shared underlying series on read.

Fixed: `fill_forward` is now a causal as-of lookup (last observation ≤ requested date) with no mutation; `interpolate` keeps its semantics but is documented as non-causal (it necessarily uses surrounding, including future, observations) with `fill_forward` recommended for backtesting.

### 2. `MeanReversionTrigger` could never run (backtests/triggers.py)

Three independent bugs: (a) `AddTradeActionInfo(scaling=...)` omitted the required `next_schedule` namedtuple field → `TypeError` on the first signal; (b) `self._current_position = 0` typo (attribute used everywhere else has no underscore) left exit state stuck; (c) the short-exit comparison was inverted — a short entered above the rolling mean exited when price was *above* the mean rather than on reversion below it. All three fixed; entries/exits are now symmetric; the z-score entry logic is untouched.

### 3. `PredefinedAssetBacktest.get_costs` always crashed (backtests/backtest_objects.py)

`order.execution_quantity(self.data_handler)` — every `execution_quantity` in the Order family takes no arguments. Fixed the call site.

### 4. Additional fixes

- **Multi-currency cash accrual** (`OisFixingCashAccrualModel`): a `return` inside the first loop iteration accrued *all* currencies at the first currency's OIS curve; now each currency accrues with its own curve.
- **Sortino** (`summary_stats`): downside deviation divided by the count of negative days rather than total N, overstating downside vol inconsistently across strategies; now standard (squared below-zero deviations over total N). The silent `except` around `trade_ledger()` now logs.
- **SEIRModel** (timeseries/statistics.py): fixed-parameter flags tested `self.beta`/`gamma` — bound methods, always truthy — so `*_fixed` was always miscomputed; now uses `beta_init/gamma_init/sigma_init is None`, matching SIRModel.
- **`annualize` docstring** (timeseries/econometrics.py): documented √F scaling as suitable for "annualizing daily or monthly returns" with a returns example; corrected to volatility-dimension quantities only (docs-only, no numeric change).
- **Import-frozen datetime defaults**: `dt.datetime.now()`/`today()` in signature defaults of `get_intraday_factor_data`, `resolve_assets`, `get_many_asset_xrefs` are evaluated once at import; long-running kernels query ever-staler windows. Now `Optional[...] = None`, resolved per call.

### Tests

New `gs_quant/test/backtest/test_audit_regressions.py` — 7 offline tests (no API/session needed): no-lookahead + no-mutation for date and datetime indices, the full mean-reversion long/short entry/exit cycle (the short-exit case fails on the pre-fix code), `AddTradeActionInfo` construction, `OrderCost.execution_quantity()`, and the Sortino math. **7 passed; the full existing `gs_quant/test/backtest/` suite passes 47/47 (zero regressions).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)