### PR TITLE
Improve error message for invalid OAuth scope (#32)

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,3 +1,4 @@
 gs-quant
 Copyright 2018-2019 Goldman Sachs
 This product contains code copyright Scott Weinstein, licensed under Apache 2.0 license
+This product contains code copyright Dipesh Pandit, licensed under Apache 2.0 license

--- a/dco/Dipesh Pandit.dco
+++ b/dco/Dipesh Pandit.dco
@@ -1,0 +1,9 @@
+1) I, Dipesh Pandit, certify that all work committed with the commit message
+"covered by: Dipesh Pandit.dco" is my original work and I own the copyright
+to this work. I agree to contribute this code under the Apache 2.0 license.
+
+2) I understand and agree all contribution including all personal
+information I submit with it is maintained indefinitely and may be
+redistributed consistent with the open source license(s) involved.
+
+This certification is effective for all code contributed from 2026-07-18 to 9999-01-01.

--- a/gs_quant/session.py
+++ b/gs_quant/session.py
@@ -12,6 +12,8 @@ software distributed under the License is distributed on ans
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
+
+Portions copyright Dipesh Pandit. Licensed under Apache 2.0 license
 """
 
 import asyncio
@@ -1210,6 +1212,17 @@ class OAuth2Session(GsSession):
         }
         reply = self._session.post(self.auth_url, data=auth_data, verify=self.verify)
         if reply.status_code != 200:
+            try:
+                error = json.loads(reply.text)
+            except (ValueError, TypeError):
+                error = {}
+            if error.get('error') == 'invalid_scope':
+                message = (
+                    'Your application account is not authorized for one or more of the requested '
+                    'scopes: {}. Please ask your Marquee administrator to grant these scopes to '
+                    'your application account.'.format(', '.join(self.scopes))
+                )
+                raise MqAuthenticationError(reply.status_code, message, context=self.auth_url)
             raise MqAuthenticationError(reply.status_code, reply.text, context=self.auth_url)
         response = json.loads(reply.text)
         self.token = response['access_token']

--- a/gs_quant/test/test_session.py
+++ b/gs_quant/test/test_session.py
@@ -12,10 +12,17 @@ software distributed under the License is distributed on an
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
+
+Portions copyright Dipesh Pandit. Licensed under Apache 2.0 license
 """
 
+import json
 import pickle
+from unittest import mock
 
+import pytest
+
+from gs_quant.errors import MqAuthenticationError
 from gs_quant.session import GsSession, Environment
 
 
@@ -24,3 +31,38 @@ def test_session_pickle():
     pk = pickle.dumps(session)
     unpk = pickle.loads(pk)
     assert unpk is not None
+
+
+def _session_with_reply(status_code, text):
+    session = GsSession.get(Environment.PROD, 'fake_client_id', 'fake_secret', scopes=('read_product_data',))
+    reply = mock.Mock(status_code=status_code, text=text)
+    session._session = mock.Mock()
+    session._session.post.return_value = reply
+    return session
+
+
+def test_authenticate_invalid_scope_message():
+    body = json.dumps({
+        'error': 'invalid_scope',
+        'error_description': 'The requested scope(s) must be blank or a subset of the provided scopes.',
+    })
+    session = _session_with_reply(400, body)
+
+    with pytest.raises(MqAuthenticationError) as exc_info:
+        session._authenticate()
+
+    message = exc_info.value.message
+    assert 'not authorized' in message
+    assert 'read_product_data' in message
+    # The raw OAuth error body should not leak into the friendly message
+    assert 'error_description' not in message
+
+
+def test_authenticate_non_scope_error_preserves_raw_text():
+    body = json.dumps({'error': 'invalid_client'})
+    session = _session_with_reply(401, body)
+
+    with pytest.raises(MqAuthenticationError) as exc_info:
+        session._authenticate()
+
+    assert exc_info.value.message == body


### PR DESCRIPTION
## Summary
Fixes the overly verbose error text shown when an application account lacks a
requested OAuth scope (issue #32). Previously the raw `invalid_scope` JSON body
from the GS token endpoint was surfaced verbatim in `MqAuthenticationError`.
Now that case is detected and a concise, human-readable message naming the
requested scopes is raised instead. All other authentication errors are
unchanged.

**Before:**
status: 400, message: {"error_description":"The requested scope(s) must be blank or a subset of the provided scopes.","error":"invalid_scope"}



**After:**
status: 400, message: Your application account is not authorized for one or more of the requested scopes: read_product_data, run_analytics. Please ask your Marquee administrator to grant these scopes to your application account.



Closes #32

## Testing
- Added unit tests in `gs_quant/test/test_session.py` covering the `invalid_scope`
  case and confirming non-scope errors still preserve the raw response text.
- Validated end-to-end against the exact 400 response body the token endpoint
  returns. This is a message-formatting change, so it did not require a live
  Marquee account.

## Notes for maintainers
- This is my first contribution, so the DCO (`dco/Dipesh Pandit.dco`) and the
  corresponding NOTICE.txt line are included in this PR.
- The message lists all scopes sent to the server, which includes the default
  scopes that `GsSession.get` auto-adds. The server response does not identify
  which specific scope was rejected. Happy to narrow this to only the
  user-supplied scopes if you would prefer.
- The issue suggested including a "request scopes at URL" link, but I could not
  find a canonical URL in the repo. Let me know what to point to and I will add it.