### PR TITLE
Relax pydash version constraint

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,3 +1,4 @@
 gs-quant
 Copyright 2018-2019 Goldman Sachs
 This product contains code copyright Scott Weinstein, licensed under Apache 2.0 license
+This product contains code copyright Sadat Tarique, licensed under Apache 2.0 license

--- a/dco/Sadat Tarique.dco
+++ b/dco/Sadat Tarique.dco
@@ -1,0 +1,9 @@
+1) I, Sadat Tarique, certify that all work committed with the commit message
+"covered by: Sadat Tarique.dco" is my original work and I own the copyright
+to this work. I agree to contribute this code under the Apache 2.0 license.
+
+2) I understand and agree all contribution including all personal
+information I submit with it is maintained indefinitely and may be
+redistributed consistent with the open source license(s) involved.
+
+This certification is effective for all code contributed from 2026-08-03 to 9999-01-01.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "opentelemetry-api",
     "opentelemetry-sdk",
     "pandas>=1.4",
-    "pydash<7.0.0",
+    "pydash",
     "python-dateutil>=2.7.0",
     "requests",
     "httpx>=0.28.1",


### PR DESCRIPTION
## Summary
- Removes the `pydash<7.0.0` upper bound in `pyproject.toml`, which blocked installation in environments where only pydash 7.x+ is available.
- Adds required DCO (`dco/Sadat Tarique.dco`) and corresponding `NOTICE.txt` line per CONTRIBUTING.md.

Fixes #336

## Test plan
- [x] Installed gs-quant with the unconstrained `pydash` dependency (resolved to pydash 8.0.6)
- [x] Verified every pydash API used in the codebase (`get`, `has`, `set_`, `chunk`, `flatten`, `decapitalize`, `camel_case`, `snake_case`, `unset`) works correctly on pydash 8.0.6
- [x] Ran the test suites for all modules importing pydash directly (`test_dataset.py`, `test_entitlements.py`, `test_risk_model_utils.py`, `test_baskets.py`, `test_measures_reports.py`, `test_measures_risk_models.py`, `test_backtesting.py`, `test_workspace.py`) — 90/90 passing