### PR TITLE
Fix LinearRegression prediction with constant inputs

### DIFF
--- a/gs_quant/test/timeseries/test_statistics.py
+++ b/gs_quant/test/timeseries/test_statistics.py
@@ -12,6 +12,8 @@ software distributed under the License is distributed on an
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
+
+Portions copyright Muhammad Mudassir. Licensed under Apache 2.0 license.
 """
 
 import datetime as dt
@@ -817,6 +819,16 @@ def test_regression():
         [pd.Series([2.0, 3.0], index=dates_predict), pd.Series([6.0, 7.0], index=dates_predict)]
     )
     expected = pd.Series([30.0, 34.0], index=dates_predict)
+    assert_series_equal(predicted, expected)
+
+    constant_dates_predict = [dt.date(2019, 2, 3), dt.date(2019, 2, 4)]
+    predicted = regression.predict(
+        [
+            pd.Series([2.0, 2.0], index=constant_dates_predict),
+            pd.Series([6.0, 6.0], index=constant_dates_predict),
+        ]
+    )
+    expected = pd.Series([30.0, 30.0], index=constant_dates_predict)
     assert_series_equal(predicted, expected)
 
     np.testing.assert_almost_equal(regression.standard_deviation_of_errors(), 0)

--- a/gs_quant/timeseries/statistics.py
+++ b/gs_quant/timeseries/statistics.py
@@ -9,6 +9,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+# Portions copyright Muhammad Mudassir. Licensed under Apache 2.0 license
 #
 #
 # Marquee Plot Service will attempt to make public functions (not prefixed with _) from this module available.
@@ -1158,7 +1159,9 @@ class LinearRegression:
         :return: predicted values
         """
         df = pd.concat(X_predict, axis=1) if isinstance(X_predict, list) else X_predict.to_frame()
-        return self._res.predict(sm.add_constant(df) if self._fit_intercept else df)
+        if self._fit_intercept:
+            df = sm.add_constant(df, has_constant='add')
+        return self._res.predict(df)
 
     @plot_method
     def standard_deviation_of_errors(self) -> float:


### PR DESCRIPTION
## Summary

Fixes `LinearRegression.predict` when prediction inputs contain constant-valued columns and the regression was fitted with an intercept.

- Explicitly adds the intercept column during prediction with `has_constant='add'` when `fit_intercept=True`.
- Adds regression coverage for constant prediction inputs.
- Preserves the existing behavior for models fitted without an intercept.

## Problem

`statsmodels.add_constant` may treat a constant-valued prediction column as an existing constant and therefore skip adding the intercept column.

For a `LinearRegression` model that was fitted with an intercept, prediction should use the same design-matrix structure. Explicitly using `has_constant='add'` ensures that the intercept column is present even when the prediction inputs themselves are constant.

## DCO

My prerequisite DCO submission is #366.

The code commit contains:

`covered by: Muhammad Mudassir.dco`

The modified files also contain the required copyright notice.

## Validation

Validated locally against the current `master`:

- `pytest gs_quant/test/timeseries/test_statistics.py::test_regression -q` — 1 passed
- `pytest gs_quant/test/timeseries/test_statistics.py -q` — 24 passed
- `git diff --check` — clean

No new dependencies are introduced.